### PR TITLE
Fix "trace" initialization settings decoding

### DIFF
--- a/Sources/JsonRpcProtocol/Decoders.swift
+++ b/Sources/JsonRpcProtocol/Decoders.swift
@@ -46,7 +46,7 @@ extension InitializeParams {
         //let initializationOptions = try type(of: initializationOptions).decode(json["initializationOptions"])
         let initializationOptions: Any? = nil
         let capabilities = try ClientCapabilities.decode(data["capabilities"])
-        let trace = try TraceSetting.decode(data["trace"])
+        let trace = try data["trace"].map { try TraceSetting.decode($0) }
 
         return InitializeParams(
             processId: processId,


### PR DESCRIPTION
The "trace" settings is optional in the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialize-request).
In the current implementation, it's parsing it as if it was _mandatory_.